### PR TITLE
Add missing packages on some DEs

### DIFF
--- a/build.py
+++ b/build.py
@@ -538,7 +538,7 @@ def start_build(verbose: bool, local_path: str, kernel_type: str, dev_release: b
         case _:
             print_error("DISTRO NAME NOT FOUND! Please create an issue")
             exit(1)
-    distro.config(build_options["de_name"], build_options["distro_version"], root_partuuid, verbose)
+    distro.config(build_options["de_name"], build_options["distro_version"], build_options["username"], root_partuuid, verbose)
 
     post_config(build_options["rebind_search"])
 

--- a/distro/arch.py
+++ b/distro/arch.py
@@ -1,7 +1,7 @@
 from functions import *
 
 
-def config(de_name: str, distro_version: str, root_partuuid: str, verbose: bool) -> None:
+def config(de_name: str, distro_version: str, username: str, root_partuuid: str, verbose: bool) -> None:
     set_verbose(verbose)
     print_status("Configuring Arch")
 
@@ -48,20 +48,22 @@ def config(de_name: str, distro_version: str, root_partuuid: str, verbose: bool)
         case "mate":
             print_status("Installing MATE")
             # no wayland support in mate
-            chroot("pacman -S --noconfirm mate mate-extra xorg xorg-server lightdm lightdm-gtk-greeter")
+            chroot("pacman -S --noconfirm mate mate-extra xorg xorg-server lightdm lightdm-gtk-greeter firefox network-manager-applet nm-connection-editor")
             chroot("systemctl enable lightdm.service")
         case "xfce":
             print_status("Installing Xfce")
             # no wayland support in xfce
-            chroot("pacman -S --noconfirm xfce4 xfce4-goodies xorg xorg-server lightdm lightdm-gtk-greeter")
+            chroot("pacman -S --noconfirm xfce4 xfce4-goodies xorg xorg-server lightdm lightdm-gtk-greeter firefox network-manager-applet nm-connection-editor")
             chroot("systemctl enable lightdm.service")
+            install_pamac(username)
         case "lxqt":
             print_status("Installing LXQt")
-            chroot("pacman -S --noconfirm lxqt breeze-icons xorg xorg-server sddm")
+            chroot("pacman -S --noconfirm lxqt breeze-icons xorg xorg-server sddm firefox networkmanager-qt network-manager-applet nm-connection-editor")
             chroot("systemctl enable sddm.service")
+            install_pamac(username)
         case "deepin":
             print_status("Installing deepin")
-            chroot("pacman -S --noconfirm deepin deepin-kwin deepin-extra xorg xorg-server lightdm")
+            chroot("pacman -S --noconfirm deepin deepin-kwin deepin-extra xorg xorg-server lightdm kde-applications firefox")
             # enable deepin specific login style
             with open("/mnt/eupnea/etc/lightdm/lightdm.conf", "a") as conf:
                 conf.write("greeter-session=lightdm-deepin-greeter")
@@ -116,3 +118,8 @@ def chroot(command: str):
         bash(f'arch-chroot /mnt/eupnea bash -c "{command}"')
     else:
         bash(f'arch-chroot /mnt/eupnea bash -c "{command}" 2>/dev/null 1>/dev/null')  # supress all output
+
+# Installs a gui packages manager on DEs that don't include one.
+def install_pamac(username: str):
+    bash(f'su - {username} -c "cd /tmp; git clone https://aur.archlinux.org/pamac-nosnap.git"')
+    bash(f'su - {username} -s /usr/bin/bash -c "cd /tmp/pamac-nosnap; makepkg -si --noconfirm"}')

--- a/distro/debian.py
+++ b/distro/debian.py
@@ -1,7 +1,7 @@
 from functions import *
 
 
-def config(de_name: str, distro_version: str, root_partuuid: str, verbose: bool) -> None:
+def config(de_name: str, distro_version: str, username: str, root_partuuid: str, verbose: bool) -> None:
     set_verbose(verbose)
     print_status("Configuring Debian")
 
@@ -44,7 +44,7 @@ def config(de_name: str, distro_version: str, root_partuuid: str, verbose: bool)
         case "budgie":
             print_status("Installing Budgie")
             chroot("DEBIAN_FRONTEND=noninteractive apt-get install -y budgie-desktop budgie-indicator-applet "
-                   "budgie-core lightdm lightdm-gtk-greeter")
+                   "budgie-core lightdm lightdm-gtk-greeter gnome-terminal firefox")
             chroot("systemctl enable lightdm.service")
         case "cli":
             print_status("Skipping desktop environment install")

--- a/distro/fedora.py
+++ b/distro/fedora.py
@@ -1,7 +1,7 @@
 from functions import *
 
 
-def config(de_name: str, distro_version: str, root_partuuid: str, verbose: bool) -> None:
+def config(de_name: str, distro_version: str, username: str, root_partuuid: str, verbose: bool) -> None:
     set_verbose(verbose)
     print_status("Configuring Fedora")
 

--- a/distro/ubuntu.py
+++ b/distro/ubuntu.py
@@ -28,7 +28,7 @@ def config(de_name: str, distro_version: str, username: str, root_partuuid: str,
         case "xfce":
             print_status("Installing Xfce")
             chroot("apt-get install -y --no-install-recommends xubuntu-desktop gnome-software")
-            chroot("apt-get install -y xfce4-goodies ubuntu-software")
+            chroot("apt-get install -y xfce4-goodies")
         case "lxqt":
             print_status("Installing LXQt")
             chroot("apt-get install -y lubuntu-desktop")

--- a/distro/ubuntu.py
+++ b/distro/ubuntu.py
@@ -1,7 +1,7 @@
 from functions import *
 
 
-def config(de_name: str, distro_version: str, root_partuuid: str, verbose: bool) -> None:
+def config(de_name: str, distro_version: str, username: str, root_partuuid: str, verbose: bool) -> None:
     set_verbose(verbose)
     print_status("Configuring Ubuntu")
 
@@ -27,8 +27,8 @@ def config(de_name: str, distro_version: str, root_partuuid: str, verbose: bool)
             chroot("apt-get install -y ubuntu-mate-desktop")
         case "xfce":
             print_status("Installing Xfce")
-            chroot("apt-get install -y --no-install-recommends xubuntu-desktop")
-            chroot("apt-get install -y xfce4-goodies")
+            chroot("apt-get install -y --no-install-recommends xubuntu-desktop gnome-software")
+            chroot("apt-get install -y xfce4-goodies ubuntu-software")
         case "lxqt":
             print_status("Installing LXQt")
             chroot("apt-get install -y lubuntu-desktop")


### PR DESCRIPTION
Installs a browser and gui package manager on some desktops that were missing them. Arch uses pamac from the AUR as the gui package manager.